### PR TITLE
bitcoin -> gcoin

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -60,11 +60,11 @@ bin_PROGRAMS =
 TESTS =
 
 if BUILD_BITCOIND
-  bin_PROGRAMS += bitcoind
+  bin_PROGRAMS += gcoind
 endif
 
 if BUILD_BITCOIN_UTILS
-  bin_PROGRAMS += bitcoin-cli bitcoin-tx
+  bin_PROGRAMS += gcoin-cli bitcoin-tx
 endif
 
 .PHONY: FORCE
@@ -314,15 +314,15 @@ nodist_libbitcoin_util_a_SOURCES = $(srcdir)/obj/build.h
 #
 
 # bitcoind binary #
-bitcoind_SOURCES = bitcoind.cpp
-bitcoind_CPPFLAGS = $(BITCOIN_INCLUDES)
-bitcoind_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+gcoind_SOURCES = bitcoind.cpp
+gcoind_CPPFLAGS = $(BITCOIN_INCLUDES)
+gcoind_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 
 if TARGET_WINDOWS
-bitcoind_SOURCES += bitcoind-res.rc
+gcoind_SOURCES += bitcoind-res.rc
 endif
 
-bitcoind_LDADD = \
+gcoind_LDADD = \
   $(LIBBITCOIN_SERVER) \
   $(LIBBITCOIN_COMMON) \
   $(LIBBITCOIN_UNIVALUE) \
@@ -333,23 +333,23 @@ bitcoind_LDADD = \
   $(LIBSECP256K1)
 
 if ENABLE_WALLET
-bitcoind_LDADD += libbitcoin_wallet.a
+gcoind_LDADD += libbitcoin_wallet.a
 endif
 
-bitcoind_LDADD += $(BOOST_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(SYSTEMD_JOURNAL_LIBS)
+gcoind_LDADD += $(BOOST_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(SYSTEMD_JOURNAL_LIBS)
 #
 
 # bitcoin-cli binary #
-bitcoin_cli_SOURCES = bitcoin-cli.cpp
-bitcoin_cli_CPPFLAGS = $(BITCOIN_INCLUDES)
-bitcoin_cli_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+gcoin_cli_SOURCES = bitcoin-cli.cpp
+gcoin_cli_CPPFLAGS = $(BITCOIN_INCLUDES)
+gcoin_cli_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 
 if TARGET_WINDOWS
-bitcoin_cli_SOURCES += bitcoin-cli-res.rc
+gcoin_cli_SOURCES += bitcoin-cli-res.rc
 endif
 
 # bitcoin-cli binary #
-bitcoin_cli_LDADD = \
+gcoin_cli_LDADD = \
   $(LIBBITCOIN_CLI) \
   $(LIBBITCOIN_UTIL) \
   $(LIBSECP256K1) \

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -119,7 +119,7 @@ bool AppInit(int argc, char* argv[])
         fDaemon = GetBoolArg("-daemon", false);
         if (fDaemon) {
 
-            bool fGcoin = GetBoolArg("-gcoin", false);
+            bool fGcoin = GetBoolArg("-gcoin", true);
             if (fGcoin)
                 fprintf(stdout, "gCoin server starting\n");
             else

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -110,7 +110,7 @@ CBaseChainParams::Network NetworkIdFromCommandLine()
 {
     bool fRegTest = GetBoolArg("-regtest", false);
     bool fTestNet = GetBoolArg("-testnet", false);
-    bool fGCoin = GetBoolArg("-gcoin", false);
+    bool fGCoin = GetBoolArg("-gcoin", true);
 
     if (fTestNet && fRegTest)
         return CBaseChainParams::MAX_NETWORK_TYPES;


### PR DESCRIPTION
1. Replace bitocin by gcoin.
2. Set gcoin to default mode.

Usage:
start gcoin:
    old : bitcoind -gcoin [args]
    new : gcoind [args]

call rpc: 
    old : bitcoin-cli -gcoin [rpc]
    new : gcoin-cli [rpc]
