### PR TITLE
Remove the on-disk caching of block miner #32

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -463,12 +463,10 @@ class BlockMiner : public CacheInterface<Tc_t, Te_t>
 public:
     BlockMiner()
     {
-        filename_ = "miner.dat";
     }
 
     ~BlockMiner()
     {
-        filename_ = "";
     }
 
     bool Add(const Te_t &e);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1119,10 +1119,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             uiInterface.InitMessage(_("Error loading license.dat: Backup corrupted"));
             return false;
         }
-        if (!pminer->ReadDisk()) {
-            uiInterface.InitMessage(_("Error loading miner.dat: Backup corrupted"));
-            return false;
-        }
         if (!pactivate->ReadDisk()) {
             uiInterface.InitMessage(_("Error loading activate.dat: Backup corrupted"));
             return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2725,8 +2725,6 @@ bool WriteCacheToDisk(const int nHeight)
         return error("%s() : alliance_member cache writing fail", __func__);
     if(!plicense->WriteDisk(nHeight))
         return error("%s() : color_license cache writing fail", __func__);
-    if(!pminer->WriteDisk(nHeight))
-        return error("%s() : block_miner cache writing fail", __func__);
     if(!pactivate->WriteDisk(nHeight))
         return error("%s() : activate_address_with_color cache writing fail", __func__);
     if(!porder->WriteDisk(nHeight))
@@ -5176,7 +5174,6 @@ bool CVerifyDB::VerifyDB(CCoinsView *coinsview, int nCheckLevel, int nCheckDepth
     set<int> lheight;
     lheight.insert(palliance->BackupHeight());
     lheight.insert(plicense->BackupHeight());
-    lheight.insert(pminer->BackupHeight());
     lheight.insert(pactivate->BackupHeight());
     lheight.insert(porder->BackupHeight());
     int backupHeight = *lheight.begin();


### PR DESCRIPTION
The miner cache is updated when `ConnectBlock()`.
On-disk caching is unnecessary for block miner list.
