### PR TITLE
Include RPM specs for CentOS and Fedora in git

### DIFF
--- a/contrib/rpm-openssl/gcoin-compat-openssl.spec
+++ b/contrib/rpm-openssl/gcoin-compat-openssl.spec
@@ -1,0 +1,76 @@
+Name:       gcoin-compat-openssl
+Version:    1.0.2h
+Release:    1%{?dist}
+Summary:    OpenSSL shared libraries compiled with secp256k1 support
+
+Group:      System Environment/Libraries
+License:    OpenSSL
+URL:        https://www.openssl.org
+Source0:    https://www.openssl.org/source/openssl-%{version}.tar.gz
+
+%description
+OpenSSL shared libraries package specifically made to support Gcoin
+blockchain software on RHEL 7 and CentOS 7.
+
+%package devel
+Summary:    OpenSSL development files used to compile Gcoin
+Group:      Development/Libraries
+Requires:   %{name}%{?_isa} = %{version}-%{release}
+
+%description devel
+OpenSSL development files needed to compile Gcoin blockchain software
+on RHEL 7 and CentOS 7.
+
+%package static
+Summary:    OpenSSL static libraries compiled with secp256k1 support
+Group:      Development/Libraries
+Requires:   %{name}%{?_isa} = %{version}-%{release}
+
+%description static
+OpenSSL static libraries package with secp256k1 support on RHEL 7 and CentOS 7.
+
+
+%prep
+%setup -q -n openssl-%{version}
+
+
+%build
+export CC="gcc %{optflags} %{__global_ldflags}"
+./config \
+    --prefix=%{_prefix} --libdir=%{_lib}/%{name} \
+    no-ssl2 no-ssl3 no-dtls no-idea no-mdc2 no-rc5 no-ec2m no-gost no-srp \
+    no-weak-ssl-ciphers shared
+make depend MAKEDEPPROG="gcc"
+make all
+
+
+%install
+make install_sw INSTALL_PREFIX=%{buildroot}
+rm -r %{buildroot}%{_prefix}/bin
+rm -r %{buildroot}%{_prefix}/ssl
+rm -r %{buildroot}%{_libdir}/%{name}/pkgconfig
+mkdir %{buildroot}%{_includedir}/%{name}
+mv %{buildroot}%{_includedir}/openssl %{buildroot}%{_includedir}/%{name}
+find %{buildroot}%{_libdir}/%{name} -name '*.so' -exec chmod u+w '{}' ';'
+
+
+%files
+%{_libdir}/%{name}/libcrypto.so.1.0.0
+%{_libdir}/%{name}/libssl.so.1.0.0
+%{_libdir}/%{name}/engines
+%license LICENSE
+%doc FAQ NEWS README
+
+%files devel
+%{_includedir}/%{name}/openssl
+%{_libdir}/%{name}/libcrypto.so
+%{_libdir}/%{name}/libssl.so
+
+%files static
+%{_libdir}/%{name}/libcrypto.a
+%{_libdir}/%{name}/libssl.a
+
+
+%changelog
+* Tue Jul 05 2016 Ting-Wei Lan <lantw44@gmail.com> - 1.0.2h-1
+- Initial public packaging

--- a/gcoin-community.spec
+++ b/gcoin-community.spec
@@ -1,0 +1,64 @@
+Name:       gcoin-community
+Version:    1.1.2
+Release:    1%{?dist}
+Summary:    Gcoin core daemon - reference client and server
+
+Group:      Applications/System
+License:    ASL 2.0
+URL:        http://g-coin.org
+Source0:    https://github.com/OpenNetworking/%{name}/archive/v%{version}.tar.gz
+
+BuildRequires: autoconf automake libtool
+BuildRequires: boost-devel libdb-cxx-devel
+BuildRequires: pkgconfig(openssl)
+BuildRequires: pkgconfig(libsystemd)
+
+%if 0%{?rhel} && 0%{?rhel} <= 7
+BuildRequires: gcoin-compat-openssl-devel
+%global openssl_includedir  %{_includedir}/gcoin-compat-openssl
+%global openssl_libdir      %{_libdir}/gcoin-compat-openssl
+%endif
+
+%description
+Gcoin blockchain is an open-source software built for next-generation
+digital infrastructure, the distributed ledger.
+
+
+%prep
+%setup -q -n %{name}-%{version}
+
+
+%build
+autoreconf -if
+%configure \
+%if 0%{?rhel} && 0%{?rhel} <= 7
+    CRYPTO_CFLAGS='-I%{openssl_includedir}' \
+    CRYPTO_LIBS='%{openssl_libdir}/libcrypto.so' \
+    SSL_CFLAGS='-I%{openssl_includedir}' \
+    SSL_LIBS='%{openssl_libdir}/libssl.so' \
+    LDFLAGS='%{__global_ldflags} -Wl,--enable-new-dtags -Wl,-rpath,%{openssl_libdir}' \
+%endif
+    --enable-systemd-journal --without-miniupnpc CXX="c++ -std=gnu++03"
+%make_build
+
+
+%install
+install -m 755 -d %{buildroot}%{_bindir}
+install -m 755 src/gcoind %{buildroot}%{_bindir}
+install -m 755 src/gcoin-cli %{buildroot}%{_bindir}
+
+
+%check
+make check
+
+
+%files
+%{_bindir}/gcoind
+%{_bindir}/gcoin-cli
+%license COPYING
+%doc README.md
+
+
+%changelog
+* Tue Jul 05 2016 Ting-Wei Lan <lantw44@gmail.com> - 1.1.2-1
+- Initial public packaging


### PR DESCRIPTION
Source RPMs for stable releases can be created with:

```
spectool -g -A -R gcoin-community.spec
rpmbuild -bs gcoin-community.spec
```

Source RPMs for git snapshots can be created with:

```
tito init
tito build --srpm --offline --test
```

Tito 0.6.6 with release number fix (https://github.com/dgoodwin/tito/pull/224.patch) is required.

Public builds:
https://copr.fedorainfracloud.org/coprs/lantw44/gcoin-community/
