### PR TITLE
Put the data into "main" directory when running gcoind

### DIFF
--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -18,6 +18,7 @@ public:
     CBaseMainParams()
     {
         nRPCPort = 26957;
+        strDataDir = "main";
     }
 };
 static CBaseMainParams mainParams;


### PR DESCRIPTION
Separate the location of the data in ~/.gcoin into a independent directory
