### PR TITLE
Apply multi currency to RPCs

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -22,6 +22,8 @@ static const int64_t MAX_MONEY = 10000000000ll * COIN;
 typedef uint32_t type_Color;
 typedef uint32_t tx_type;
 
+typedef std::map<type_Color, CAmount> colorAmount_t;
+
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
 /** Type-safe wrapper class to for fee rates

--- a/src/coins.h
+++ b/src/coins.h
@@ -333,7 +333,7 @@ struct CCoinsStats
     uint64_t nTransactionOutputs;
     uint64_t nSerializedSize;
     uint256 hashSerialized;
-    std::map<type_Color, CAmount> mapTotalAmount;
+    colorAmount_t mapTotalAmount;
 
     CCoinsStats() : nHeight(0), nTransactions(0), nTransactionOutputs(0), nSerializedSize(0) {}
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -858,7 +858,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state)
         return state.DoS(100, error("CheckTransaction(): size limits failed"),
                          REJECT_INVALID, "bad-txns-oversize");
 
-    map<type_Color, CAmount> nValueOut_;
+    colorAmount_t nValueOut_;
     BOOST_FOREACH(const CTxOut& txout, tx.vout)
     {
         if (txout.nValue < 0)
@@ -2046,7 +2046,7 @@ bool CheckTxFeeAndColor(const CTransaction tx, const CBlock *pblock, bool fCheck
     }
 
     // fee = vin - vout
-    map<type_Color, int64_t> Input;
+    colorAmount_t Input;
     BOOST_FOREACH(const CTxIn txin, tx.vin) {
         TxInfo txinfo;
         if (!txinfo.init(txin.prevout, pblock)) {
@@ -2055,7 +2055,7 @@ bool CheckTxFeeAndColor(const CTransaction tx, const CBlock *pblock, bool fCheck
         }
         type_Color color = txinfo.GetTxOutColorOfIndex(txin.prevout.n);
         int64_t value = txinfo.GetTxOutValueOfIndex(txin.prevout.n);
-        map<type_Color, int64_t>::iterator it = Input.find(color);
+        colorAmount_t::iterator it = Input.find(color);
         if (it == Input.end()) {
             Input.insert(make_pair(color, value));
         } else {
@@ -2065,7 +2065,7 @@ bool CheckTxFeeAndColor(const CTransaction tx, const CBlock *pblock, bool fCheck
     unsigned int index = 0;
     BOOST_FOREACH(const CTxOut txout, tx.vout) {
         type_Color color = txout.color;
-        map<type_Color, int64_t>::iterator it = Input.find(color);
+        colorAmount_t::iterator it = Input.find(color);
         if (it == Input.end()) {
             LogPrintf("%s : Cannot find match input color\n", __func__);
             return false;
@@ -2089,7 +2089,7 @@ bool CheckTxFeeAndColor(const CTransaction tx, const CBlock *pblock, bool fCheck
         return false;
     }
     if (fCheckFee) {
-        map<type_Color, int64_t>::iterator it = Input.begin();
+        colorAmount_t::iterator it = Input.begin();
         if (!TxFee.CheckFee(it->first, it->second)) {
             LogPrintf("%s : Incorrect fee\n", __func__);
             return false;
@@ -2792,7 +2792,7 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
             CBlockIndex *pindexPrev = mapBlockIndex.find(inputs.GetBestBlock())->second;
             int nSpendHeight = pindexPrev->nHeight + 1;
             CAmount nValueIn = 0;
-            map<type_Color, CAmount> nValueIn_;
+            colorAmount_t nValueIn_;
             for (unsigned int i = 0; i < tx.vin.size(); i++)
             {
                 const COutPoint &prevout = tx.vin[i].prevout;

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -92,7 +92,7 @@ CTransaction& CTransaction::operator=(const CTransaction &tx) {
 CAmount CTransaction::GetValueOut() const
 {
     CAmount nValueOut = 0;
-    std::map<type_Color, CAmount> nValueOut_;
+    colorAmount_t nValueOut_;
     for (std::vector<CTxOut>::const_iterator it(vout.begin()); it != vout.end(); ++it)
     {
         nValueOut += it->nValue;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -444,7 +444,7 @@ Value gettxoutsetinfo(const Array& params, bool fHelp)
         ret.push_back(Pair("bytes_serialized", (int64_t)stats.nSerializedSize));
         ret.push_back(Pair("hash_serialized", stats.hashSerialized.GetHex()));
         Array arrColorAmount;
-        for (map<type_Color, CAmount>::iterator it = stats.mapTotalAmount.begin(); it != stats.mapTotalAmount.end(); it++) {
+        for (colorAmount_t::iterator it = stats.mapTotalAmount.begin(); it != stats.mapTotalAmount.end(); it++) {
             Object temp;
             temp.push_back(Pair(boost::to_string(it->first), ValueFromAmount(it->second)));
             arrColorAmount.push_back(temp);

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -156,12 +156,12 @@ Value ValueFromAmount(const CAmount& amount)
     return (double)amount / (double)COIN;
 }
 
-Value ValueFromAmount(const map<type_Color, CAmount>& origin)
+Value ValueFromAmount(const colorAmount_t& origin)
 {
     Object result;
     char r1[20];
 
-    for (map<type_Color, CAmount>::const_iterator it = origin.begin(); it != origin.end(); ++it) {
+    for (colorAmount_t::const_iterator it = origin.begin(); it != origin.end(); ++it) {
         snprintf(r1, 20, "%" PRIu32, it->first);
         result.push_back(Pair(r1, ValueFromAmount(it->second)));
     }

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -147,7 +147,7 @@ extern json_spirit::Value ValueFromAmount(const CAmount& amount);
 
 extern type_Color ColorFromValue(const json_spirit::Value& value);
 extern int64_t AmountFromValueInt64(const json_spirit::Value& value);
-extern json_spirit::Value ValueFromAmount(const std::map<type_Color, CAmount>& origin);
+extern json_spirit::Value ValueFromAmount(const colorAmount_t& origin);
 
 extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
 extern std::string HelpRequiringPassphrase();

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -118,7 +118,7 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) const
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
     stats.hashBlock = GetBestBlock();
     ss << stats.hashBlock;
-    map<type_Color, CAmount> mapTotalAmount;
+    colorAmount_t mapTotalAmount;
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();
         try {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1417,7 +1417,10 @@ Value getaddressbalance(const Array& params, bool fHelp)
             "1. \"address\"     (string, required) Gcoin address.\n"
             "2. minconf         (numeric, optional, default=1) Only include transactions confirmed at least this many times.\n"
             "\nResult:\n"
-            "amount         (numeric) The total amount in gcoin received for this address.\n"
+            "[                     (json array of string : numeric)\n"
+            "  \"color\" : amount  (string : numeric) The total amount in gcoin corresponding to color received at this address\n"
+            "  ,...\n"
+            "]\n"
         );
 
     LOCK2(cs_main, pwalletMain->cs_wallet);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1249,7 +1249,10 @@ Value getbalance(const Array& params, bool fHelp)
             "2. minconf          (numeric, optional, default=1) Only include transactions confirmed at least this many times.\n"
             "3. includeWatchonly (bool, optional, default=false) Also include balance in watchonly addresses (see 'importaddress')\n"
             "\nResult:\n"
-            "amount              (numeric) The total amount in gcoin received for this account.\n"
+            "[                     (json array of string : numeric)\n"
+            "  \"color\" : amount  (string : numeric) The total amount in gcoin corresponding to color received at this account\n"
+            "  ,...\n"
+            "]\n"
             "\nExamples:\n"
             "\nThe total amount in the wallet\n"
             + HelpExampleCli("getbalance", "") +

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1120,7 +1120,10 @@ Value getreceivedbyaccount(const Array& params, bool fHelp)
             "1. \"account\"      (string, required) The selected account, may be the default account using \"\".\n"
             "2. minconf          (numeric, optional, default=1) Only include transactions confirmed at least this many times.\n"
             "\nResult:\n"
-            "amount              (numeric) The total amount in gcoin received for this account.\n"
+            "[                     (json array of string : numeric)\n"
+            "  \"color\" : amount  (string : numeric) The total amount in gcoin corresponding to color received at this account\n"
+            "  ,...\n"
+            "]\n"
             "\nExamples:\n"
             "\nAmount received by the default account with at least 1 confirmation\n"
             + HelpExampleCli("getreceivedbyaccount", "\"\"") +
@@ -1144,7 +1147,7 @@ Value getreceivedbyaccount(const Array& params, bool fHelp)
     set<CTxDestination> setAddress = pwalletMain->GetAccountAddresses(strAccount);
 
     // Tally
-    CAmount nAmount = 0;
+    map<type_Color, CAmount> colorAmount;
     for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it) {
         const CWalletTx& wtx = (*it).second;
         if (wtx.IsCoinBase() || !CheckFinalTx(wtx))
@@ -1153,12 +1156,15 @@ Value getreceivedbyaccount(const Array& params, bool fHelp)
         BOOST_FOREACH(const CTxOut& txout, wtx.vout) {
             CTxDestination address;
             if (ExtractDestination(txout.scriptPubKey, address) && IsMine(*pwalletMain, address) && setAddress.count(address))
-                if (wtx.GetDepthInMainChain() >= nMinDepth)
-                    nAmount += txout.nValue;
+                if (wtx.GetDepthInMainChain() >= nMinDepth) {
+                    if (!colorAmount.count(txout.color))
+                        colorAmount[txout.color] = 0;
+                    colorAmount[txout.color] += txout.nValue;
+                }
         }
     }
 
-    return (double)nAmount / (double)COIN;
+    return ValueFromAmount(colorAmount);
 }
 map<type_Color, CAmount> GetAccountBalance(CWalletDB& walletdb, const string& strAccount, int nMinDepth, const isminefilter& filter, map<type_Color, CAmount>& color_amount)
 {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -953,9 +953,9 @@ Value listaddressgroupings(const Array& params, bool fHelp)
             "[\n"
             "  [\n"
             "    [\n"
-            "      \"address\",     (string) The gcoin address\n"
-            "      amount,          (numeric) The amount in gcoin\n"
-            "      \"account\"      (string, optional) The account (DEPRECATED)\n"
+            "      \"address\",            (string) The gcoin address\n"
+            "      \"color\" : amount,     (string : numeric) The amount in btc corresponding to color\n"
+            "      \"account\"             (string, optional) The account (DEPRECATED)\n"
             "    ]\n"
             "    ,...\n"
             "  ]\n"
@@ -969,7 +969,7 @@ Value listaddressgroupings(const Array& params, bool fHelp)
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
     Array jsonGroupings;
-    map<CTxDestination, CAmount> balances = pwalletMain->GetAddressBalances();
+    map<CTxDestination, map<type_Color, CAmount> > balances = pwalletMain->GetAddressBalances();
     BOOST_FOREACH(set<CTxDestination> grouping, pwalletMain->GetAddressGroupings()) {
         Array jsonGrouping;
         BOOST_FOREACH(CTxDestination address, grouping) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -857,7 +857,7 @@ bool CWallet::IsFromMe(const CTransaction& tx) const
 
 CAmount CWallet::GetDebit(const CTransaction& tx, const isminefilter& filter) const
 {
-    map<type_Color, CAmount> nDebit_;
+    colorAmount_t nDebit_;
     CAmount nDebit = 0;
     BOOST_FOREACH(const CTxIn& txin, tx.vin)
     {
@@ -1000,7 +1000,7 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived,
 
 }
 
-void CWalletTx::GetAccountAmounts(const string& strAccount, std::map<type_Color, CAmount>& nReceived, std::map<type_Color, CAmount>& nSent, const isminefilter& filter) const
+void CWalletTx::GetAccountAmounts(const string& strAccount, colorAmount_t& nReceived, colorAmount_t& nSent, const isminefilter& filter) const
 {
 
     CAmount allFee;
@@ -1248,7 +1248,7 @@ CAmount CWalletTx::GetAvailableColorCredit(type_Color color, bool fUseCache) con
     return nCredit;
 }
 
-void CWalletTx::GetAvailableCredit(std::map<type_Color, int64_t> &color_amount) const
+void CWalletTx::GetAvailableCredit(colorAmount_t &color_amount) const
 {
     if (pwallet == 0)
         return;
@@ -1471,7 +1471,7 @@ CAmount CWallet::GetSendLicenseBalance(const type_Color& color) const
     return nTotal;
 }
 
-void CWallet::GetBalance(map<type_Color, CAmount>& color_amount) const
+void CWallet::GetBalance(colorAmount_t& color_amount) const
 {
     color_amount.clear();
 
@@ -1488,7 +1488,7 @@ void CWallet::GetBalance(map<type_Color, CAmount>& color_amount) const
 }
 
 
-void CWallet::GetAddressBalance(const string& strAddress, map<type_Color, CAmount>& color_amount, int nMinDepth) const
+void CWallet::GetAddressBalance(const string& strAddress, colorAmount_t& color_amount, int nMinDepth) const
 {
     color_amount.clear();
 
@@ -1518,7 +1518,7 @@ void CWallet::GetAddressBalance(const string& strAddress, map<type_Color, CAmoun
             // FIXME: what if index >= pcoin->vout.size() ?
             isminetype mine = IsMine(pcoin->vout[index]);
             if (!(IsSpent(wtxid, index)) && mine != ISMINE_NO && pcoin->vout[index].nValue > 0) {
-                map<type_Color, CAmount>::iterator it_ca = color_amount.find(pcoin->vout[index].color);
+                colorAmount_t::iterator it_ca = color_amount.find(pcoin->vout[index].color);
                 if (it_ca == color_amount.end())
                     color_amount.insert(make_pair(pcoin->vout[index].color, pcoin->vout[index].nValue));
                 else
@@ -1580,7 +1580,7 @@ CAmount CWallet::GetColorBalance(const type_Color& color) const
     return nTotal;
 }
 
-void CWallet::GetUnconfirmedBalance(map<type_Color, CAmount>& color_amount) const
+void CWallet::GetUnconfirmedBalance(colorAmount_t& color_amount) const
 {
     color_amount.clear();
 
@@ -2705,9 +2705,9 @@ int64_t CWallet::GetOldestKeyPoolTime()
     return keypool.nTime;
 }
 
-map<CTxDestination, map<type_Color, CAmount> > CWallet::GetAddressBalances()
+map<CTxDestination, colorAmount_t > CWallet::GetAddressBalances()
 {
-    map<CTxDestination, map<type_Color, CAmount> > balances;
+    map<CTxDestination, colorAmount_t > balances;
 
     {
         LOCK(cs_wallet);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2705,9 +2705,9 @@ int64_t CWallet::GetOldestKeyPoolTime()
     return keypool.nTime;
 }
 
-map<CTxDestination, CAmount> CWallet::GetAddressBalances()
+map<CTxDestination, map<type_Color, CAmount> > CWallet::GetAddressBalances()
 {
-    map<CTxDestination, CAmount> balances;
+    map<CTxDestination, map<type_Color, CAmount> > balances;
 
     {
         LOCK(cs_wallet);
@@ -2730,12 +2730,10 @@ map<CTxDestination, CAmount> CWallet::GetAddressBalances()
                     continue;
                 if (!ExtractDestination(pcoin->vout[i].scriptPubKey, addr))
                     continue;
-
                 CAmount n = IsSpent(walletEntry.first, i) ? 0 : pcoin->vout[i].nValue;
-
-                if (!balances.count(addr))
-                    balances[addr] = 0;
-                balances[addr] += n;
+                if (!balances.count(addr) || !balances[addr].count(pcoin->vout[i].color))
+                    balances[addr][pcoin->vout[i].color] = 0;
+                balances[addr][pcoin->vout[i].color] += n;
             }
         }
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -239,7 +239,7 @@ public:
     mutable CAmount nDebitCached;
     mutable CAmount nCreditCached;
     mutable CAmount nImmatureCreditCached;
-    mutable std::map<type_Color, int64_t> nAvailableCreditCached;
+    mutable colorAmount_t nAvailableCreditCached;
     mutable CAmount nWatchDebitCached;
     mutable CAmount nWatchCreditCached;
     mutable CAmount nImmatureWatchCreditCached;
@@ -364,7 +364,7 @@ public:
     CAmount GetDebit(const isminefilter& filter) const;
     CAmount GetCredit(const isminefilter& filter) const;
     CAmount GetImmatureCredit(bool fUseCache=true) const;
-    void GetAvailableCredit(std::map<type_Color, int64_t> &color_amount) const;
+    void GetAvailableCredit(colorAmount_t &color_amount) const;
     CAmount GetAvailableColorCredit(type_Color color = 0, bool fUseCache=true) const;
     CAmount GetImmatureWatchOnlyCredit(const bool& fUseCache=true) const;
     CAmount GetAvailableWatchOnlyCredit(const bool& fUseCache=true) const;
@@ -373,8 +373,8 @@ public:
     void GetAmounts(std::list<COutputEntry>& listReceived,
                     std::list<COutputEntry>& listSent, CAmount& nFee, std::string& strSentAccount, const isminefilter& filter) const;
 
-    void GetAccountAmounts(const std::string& strAccount, std::map<type_Color, CAmount>& nReceived,
-                           std::map<type_Color, CAmount>& nSent, const isminefilter& filter) const;
+    void GetAccountAmounts(const std::string& strAccount, colorAmount_t& nReceived,
+                           colorAmount_t& nSent, const isminefilter& filter) const;
 
     bool IsFromMe(const isminefilter& filter) const
     {
@@ -640,11 +640,11 @@ public:
     virtual CAmount GetVoteBalance() const;
     bool    GetLicensePubKey(const type_Color& color, CScript& scriptPubKey) const;
     virtual CAmount GetSendLicenseBalance(const type_Color& color) const;
-    void    GetBalance(std::map<type_Color, CAmount>& color_amount) const;
-    void    GetAddressBalance(const std::string& strAddress, std::map<type_Color, CAmount>& color_amount, int nMinDepth) const;
+    void    GetBalance(colorAmount_t& color_amount) const;
+    void    GetAddressBalance(const std::string& strAddress, colorAmount_t& color_amount, int nMinDepth) const;
     CAmount GetColorBalanceFromFixedAddress(const std::string& strFromAddress, const type_Color& color) const;
     CAmount GetColorBalance(const type_Color& color) const;
-    void    GetUnconfirmedBalance(std::map<type_Color, CAmount>& color_amount) const;
+    void    GetUnconfirmedBalance(colorAmount_t& color_amount) const;
     CAmount GetUnconfirmedColorBalance(const type_Color& color) const;
     CAmount GetImmatureBalance(const type_Color& color) const;
     CAmount GetWatchOnlyBalance(const type_Color& color) const;
@@ -687,7 +687,7 @@ public:
     void GetAllReserveKeys(std::set<CKeyID>& setAddress) const;
 
     std::set< std::set<CTxDestination> > GetAddressGroupings();
-    std::map<CTxDestination, std::map<type_Color, CAmount> > GetAddressBalances();
+    std::map<CTxDestination, colorAmount_t > GetAddressBalances();
 
     CAmount GetFixedAddressColorBalances(const std::string& strAddress, const type_Color& color) const;
 
@@ -862,7 +862,7 @@ class CAccountingEntry
 {
 public:
     std::string strAccount;
-    std::map<type_Color, CAmount> nCreditDebit;
+    colorAmount_t nCreditDebit;
     int64_t nTime;
     std::string strOtherAccount;
     std::string strComment;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -687,7 +687,7 @@ public:
     void GetAllReserveKeys(std::set<CKeyID>& setAddress) const;
 
     std::set< std::set<CTxDestination> > GetAddressGroupings();
-    std::map<CTxDestination, CAmount> GetAddressBalances();
+    std::map<CTxDestination, std::map<type_Color, CAmount> > GetAddressBalances();
 
     CAmount GetFixedAddressColorBalances(const std::string& strAddress, const type_Color& color) const;
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -242,14 +242,14 @@ bool CWalletDB::WriteAccountingEntry(const CAccountingEntry& acentry)
     return WriteAccountingEntry(++nAccountingEntryNumber, acentry);
 }
 
-map<type_Color, CAmount> CWalletDB::GetAccountCreditDebit(const string& strAccount)
+colorAmount_t CWalletDB::GetAccountCreditDebit(const string& strAccount)
 {
     std::list<CAccountingEntry> entries;
     ListAccountCreditDebit(strAccount, entries);
 
-    map<type_Color, CAmount> nCreditDebit;
+    colorAmount_t nCreditDebit;
     BOOST_FOREACH (const CAccountingEntry& entry, entries) {
-        for (map<type_Color, CAmount>::const_iterator it = entry.nCreditDebit.begin(); it != entry.nCreditDebit.end(); it++) {
+        for (colorAmount_t::const_iterator it = entry.nCreditDebit.begin(); it != entry.nCreditDebit.end(); it++) {
             if (!nCreditDebit.count((*it).first))
                 nCreditDebit[(*it).first] = 0;
             nCreditDebit[(*it).first] += (*it).second;

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -133,7 +133,7 @@ public:
     bool EraseDestData(const std::string &address, const std::string &key);
 
     bool WriteAccountingEntry(const CAccountingEntry& acentry);
-    std::map<type_Color, CAmount> GetAccountCreditDebit(const std::string& strAccount);
+    colorAmount_t GetAccountCreditDebit(const std::string& strAccount);
     void ListAccountCreditDebit(const std::string& strAccount, std::list<CAccountingEntry>& acentries);
 
     DBErrors ReorderTransactions(CWallet* pwallet);


### PR DESCRIPTION
The original Bitcoin core only serves single currency. Gcoin supports multi currency natively, which means the RPCs that are related to amount should serve color at the same time.
