### PR TITLE
Set default address by RPC assignfixedaddress

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -380,6 +380,7 @@ static const CRPCCommand vRPCCommands[] =
     { "wallet",             "listwalletaddress",           &listwalletaddress,           false,     false,      true },
     { "wallet",             "gennewaddress",               &gennewaddress,               false,     false,      true },
     { "wallet",             "getfixedaddress",             &getfixedaddress,             true,      false,      true },
+    { "wallet",             "assignfixedaddress",          &assignfixedaddress,          true,      false,      true },
     { "wallet",             "listonewalletaddress",        &listonewalletaddress,        false,     false,      true },
     { "wallet",             "encodelicenseinfo",           &encodelicenseinfo,           false,     false,      true },
     { "wallet",             "decodelicenseinfo",           &decodelicenseinfo,           false,     false,      true },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -237,6 +237,7 @@ extern json_spirit::Value hdgetinfo(const json_spirit::Array& params, bool fHelp
 extern json_spirit::Value getnewaddressamount(const json_spirit::Array& params, bool fHelp); // in rpcwallet.cpp
 extern json_spirit::Value gennewaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getfixedaddress(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value assignfixedaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getcolorbalance(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getaddressbalance(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getunconfirmedcolorbalance(const json_spirit::Array& params, bool fHelp);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -8,6 +8,7 @@
 #define BITCOIN_WALLET_WALLET_H
 
 #include "amount.h"
+#include "base58.h"
 #include "key.h"
 #include "keystore.h"
 #include "primitives/block.h"
@@ -679,10 +680,13 @@ public:
     bool AddKeyPool(CPubKey& key);
     bool EraseKeyPool();
     void ViewKeyPool(std::vector<CPubKey>& keys);
+    int64_t SearchKeyPool(const CBitcoinAddress& address) const;
     void ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool);
+    void ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool, const CBitcoinAddress& address);
     void KeepKey(int64_t nIndex);
     void ReturnKey(int64_t nIndex);
     bool GetKeyFromPool(CPubKey &key);
+    bool GetKeyFromPool(CPubKey &key, const CBitcoinAddress& address);
     int64_t GetOldestKeyPoolTime();
     void GetAllReserveKeys(std::set<CKeyID>& setAddress) const;
 


### PR DESCRIPTION
RPC assignfixedaddress assigns a random address or a given address owned by user.

`assignfixedaddress address(optional)`
The given `address` should be owned by the user.
Randomly assign a new generated address if `address` is not given.
