### PR TITLE
Assign alliance through genesis block #99

### DIFF
--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -78,6 +78,9 @@ public:
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
     const std::vector<SeedSpec6>& FixedSeeds() const { return vFixedSeeds; }
     const Checkpoints::CCheckpointData& Checkpoints() const { return checkpointData; }
+    /** Update genesis block content */
+    virtual void AddAlliance(const std::string& addr) {}
+    virtual void UpdateGenesis() {}
 protected:
     CChainParams() {}
 
@@ -109,7 +112,7 @@ protected:
  * Return the currently selected parameters. This won't change after app
  * startup, except for unit tests.
  */
-const CChainParams &Params();
+CChainParams &Params();
 
 /** Return parameters for the given network. */
 CChainParams &Params(CBaseChainParams::Network network);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -12,6 +12,7 @@
 
 #include "addrman.h"
 #include "amount.h"
+#include "base58.h"
 #include "cache.h"
 #include "checkpoints.h"
 #include "compat/sanity.h"
@@ -682,7 +683,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 #endif
 
     // ********************************************************* Step 2: parameter interactions
-    const CChainParams& chainparams = Params();
+    CChainParams& chainparams = Params();
 
     // Set this early so that parameter interactions go to console
     fPrintToConsole = GetBoolArg("-printtoconsole", false);
@@ -770,6 +771,18 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                 return InitError(_("Can't run with a wallet in prune mode."));
         }
 #endif
+    }
+
+    // update the genesis block content by configuration
+    if (mapArgs.count("-alliance")) {
+        set<string> setAlliance;
+        BOOST_FOREACH(string strAddr, mapMultiArgs["-alliance"]) {
+            setAlliance.insert(strAddr);
+        }
+        for (set<string>::iterator it = setAlliance.begin(); it != setAlliance.end(); it++) {
+            chainparams.AddAlliance(*it);
+        }
+        chainparams.UpdateGenesis();
     }
 
     // ********************************************************* Step 3: parameter-to-internal-flags

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4111,10 +4111,12 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
         return false;
     // add creater of first block to AE member List
     // TODO : erase if this first block fail.
-    if (GetHeight() >= 0) {
+    if (GetHeight() == 0) {
         if (palliance->NumOfMembers() == 0) {
             palliance->Add(addr);
         }
+    }
+    else if (GetHeight() > 0) {
         if (!palliance->IsMember(addr)) {
             return state.DoS(100, error("CheckBlock(): Not Alliance Member"),
                              REJECT_INVALID, "not-alliance", true);
@@ -4800,7 +4802,7 @@ bool UpdateList(const CBlockIndex *pindex)
     // Now: ignore ReadFail Block and continue checking.
     if (!ReadBlockFromDisk(block, pindex))
         return true;
-    // creater of first block must be AE
+    // if alliance is not assigned in genesis block, creater of first block must be alliance
     if (pindex->nHeight == 1 && palliance->NumOfMembers() == 0) {
         string addr = GetTxOutputAddr(block.vtx[0], 0);
         palliance->Add(addr);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -675,7 +675,7 @@ void GenerateGcoins(bool fGenerate, CWallet* pwallet, int nThreads)
 
     //only alliance member can mine block
     std::string addr = CBitcoinAddress(pubkey.GetID()).ToString();
-    if (!palliance->IsMember(addr) && chainActive.Height() != 0) {
+    if (palliance->NumOfMembers() != 0 && !palliance->IsMember(addr)) {
         mapArgs["-gen"] = "false";
         return;
     }


### PR DESCRIPTION
##### Why:

To differentiate the ability of alliance and miner, a solution to assign these roles when initiating the blockchain is necessary.  
##### How:

By assigning the initial alliance through genesis block, we are able to assign the address as an alliance. This can also differentiate each individual blockchain at the beginning through a completely different genesis block, which means that the blockchain with pre-assigned alliance cannot be connected or mine for those who are not assigned. 
##### Usage:
-  The initial alliance address can be assigned in the configuration file (i.e. gcoin.conf). With the key `alliance` following by an address, the initial alliance address can be assigned, ex. `alliance= 18JHzqnhdgVbx9xghA4BXfe75Mp4bYHCKs`. If no alliance is assigned in genesis block, the mechanism remains the same as the former method (i.e. The first block miner will be the first alliance.)  
-  The addresses in the configuration file will be recorded in the genesis block by a form of `VOTE` transaction.  
-  By importing the corresponding key of the assigned address, user can assign the address as their default address through rpc `assignfixedaddress`.  
-  Mining start!  
##### Side Effects:

Since that the genesis block can be changed through the content of configuration file, the nonce of genesis block needs to be calculated in run-time, which means a little extra time is needed when starting the node.
