### PR TITLE
Fix assignfixedaddress #106

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -144,12 +144,12 @@ Value getfixedaddress(const Array& params, bool fHelp)
 // Return the default address for current wallet.
 Value assignfixedaddress(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1)
+    if (fHelp || params.size() != 1)
         throw runtime_error(
             _(__func__) + "( \"account\" )\n"
             "\nAssign the default Gcoin address.\n"
             "\nArguments:\n"
-            "1. \"address\"     (string, optional) The address to be assigned as the default address. Randomly assign an address if no address is given.\n"
+            "1. \"address\"     (string, required) The address to be assigned as the default address.\n"
             "\nResult:\n"
             "\"address\"    (string) The default gcoin address\n"
             "\nExamples:\n"
@@ -158,21 +158,22 @@ Value assignfixedaddress(const Array& params, bool fHelp)
             + HelpExampleRpc("assignfixedaddress", "address")
         );
 
+    std::string str = params[0].get_str();
     CPubKey newDefaultKey;
     CKeyID keyID;
-    if (params.size() == 0) {
-        newDefaultKey = pwalletMain->GenerateNewKey();
-        pwalletMain->SetBestChain(chainActive.GetLocator());
-    } else if (params.size() == 1) {
-        std::string str = params[0].get_str();
-        CBitcoinAddress address;
-        if (address.SetString(str)) {
-            if (!pwalletMain->GetKeyFromPool(newDefaultKey, address))
-                throw JSONRPCError(RPC_WALLET_ERROR, "Public key for address " + str + " is not known");
-        } else {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Gcoin address or key");
+    CBitcoinAddress address;
+    if (address.SetString(str)) {
+        address.GetKeyID(keyID);
+    } else {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Gcoin address or key");
+    }
+
+    if (!pwalletMain->GetKeyFromPool(newDefaultKey, address)) {
+        if (!pwalletMain->GetPubKey(keyID, newDefaultKey)) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "Public key for address " + str + " is not known");
         }
     }
+
     if (newDefaultKey.IsValid()) {
         pwalletMain->SetDefaultKey(newDefaultKey);
         keyID = pwalletMain->vchDefaultKey.GetID();
@@ -180,7 +181,7 @@ Value assignfixedaddress(const Array& params, bool fHelp)
             throw JSONRPCError(RPC_WALLET_ERROR, "Cannot write default address");
     }
 
-    return CBitcoinAddress(keyID).ToString();
+    return str;
 }
 
 // Get a specific amount of new address.


### PR DESCRIPTION
Address is required for RPC `assignfixedaddress`.
Address can be repeatedly assigned.
Key will be removed from keypool if the given address's key is in the keypool.