### PR TITLE
RPC gettxoutaddress

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -49,7 +49,7 @@ bool CCoinsView::HaveCoins(const uint256 &txid) const { return false; }
 uint256 CCoinsView::GetBestBlock() const { return uint256(); }
 bool CCoinsView::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) { return false; }
 bool CCoinsView::GetStats(CCoinsStats &stats) const { return false; }
-bool CCoinsView::GetAddrCoins(const string &addr, CTxOutMap &mapTxOut) const { return false; }
+bool CCoinsView::GetAddrCoins(const string &addr, CTxOutMap &mapTxOut, bool fLicense) const { return false; }
 
 
 CCoinsViewBacked::CCoinsViewBacked(CCoinsView *viewIn) : base(viewIn) { }
@@ -59,7 +59,7 @@ uint256 CCoinsViewBacked::GetBestBlock() const { return base->GetBestBlock(); }
 void CCoinsViewBacked::SetBackend(CCoinsView &viewIn) { base = &viewIn; }
 bool CCoinsViewBacked::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) { return base->BatchWrite(mapCoins, hashBlock); }
 bool CCoinsViewBacked::GetStats(CCoinsStats &stats) const { return base->GetStats(stats); }
-bool CCoinsViewBacked::GetAddrCoins(const string &addr, CTxOutMap &mapTxOut) const { return base->GetAddrCoins(addr, mapTxOut); }
+bool CCoinsViewBacked::GetAddrCoins(const string &addr, CTxOutMap &mapTxOut, bool fLicense) const { return base->GetAddrCoins(addr, mapTxOut, fLicense); }
 
 CCoinsKeyHasher::CCoinsKeyHasher() : salt(GetRandHash()) {}
 
@@ -251,7 +251,7 @@ double CCoinsViewCache::GetPriority(const CTransaction &tx, int nHeight) const
     return tx.ComputePriority(dResult);
 }
 
-bool CCoinsViewCache::GetAddrCoins(const string &addr, CTxOutMap &mapTxOut) const { return base->GetAddrCoins(addr, mapTxOut); }
+bool CCoinsViewCache::GetAddrCoins(const string &addr, CTxOutMap &mapTxOut, bool fLicense) const { return base->GetAddrCoins(addr, mapTxOut, fLicense); }
 
 CCoinsModifier::CCoinsModifier(CCoinsViewCache& cache_, CCoinsMap::iterator it_, size_t usage) : cache(cache_), it(it_), cachedCoinUsage(usage) {
     assert(!cache.hasModifier);

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -3,12 +3,15 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "coins.h"
+#include "main.h"
 
 #include "memusage.h"
 #include "random.h"
 
 #include <assert.h>
 
+using std::map;
+using std::string;
 /**
  * calculate number of bytes for the bitmask, and its number of non-zero bytes
  * each bit in the bitmask represents the availability of one output, but the
@@ -46,6 +49,7 @@ bool CCoinsView::HaveCoins(const uint256 &txid) const { return false; }
 uint256 CCoinsView::GetBestBlock() const { return uint256(); }
 bool CCoinsView::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) { return false; }
 bool CCoinsView::GetStats(CCoinsStats &stats) const { return false; }
+bool CCoinsView::GetAddrCoins(const string &addr, CAddrTxOutMap &mapTxOut) const { return false; }
 
 
 CCoinsViewBacked::CCoinsViewBacked(CCoinsView *viewIn) : base(viewIn) { }
@@ -55,6 +59,7 @@ uint256 CCoinsViewBacked::GetBestBlock() const { return base->GetBestBlock(); }
 void CCoinsViewBacked::SetBackend(CCoinsView &viewIn) { base = &viewIn; }
 bool CCoinsViewBacked::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) { return base->BatchWrite(mapCoins, hashBlock); }
 bool CCoinsViewBacked::GetStats(CCoinsStats &stats) const { return base->GetStats(stats); }
+bool CCoinsViewBacked::GetAddrCoins(const string &addr, CAddrTxOutMap &mapTxOut) const { return base->GetAddrCoins(addr, mapTxOut); }
 
 CCoinsKeyHasher::CCoinsKeyHasher() : salt(GetRandHash()) {}
 
@@ -245,6 +250,8 @@ double CCoinsViewCache::GetPriority(const CTransaction &tx, int nHeight) const
     }
     return tx.ComputePriority(dResult);
 }
+
+bool CCoinsViewCache::GetAddrCoins(const string &addr, CAddrTxOutMap &mapTxOut) const { return base->GetAddrCoins(addr, mapTxOut); }
 
 CCoinsModifier::CCoinsModifier(CCoinsViewCache& cache_, CCoinsMap::iterator it_, size_t usage) : cache(cache_), it(it_), cachedCoinUsage(usage) {
     assert(!cache.hasModifier);

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -49,7 +49,7 @@ bool CCoinsView::HaveCoins(const uint256 &txid) const { return false; }
 uint256 CCoinsView::GetBestBlock() const { return uint256(); }
 bool CCoinsView::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) { return false; }
 bool CCoinsView::GetStats(CCoinsStats &stats) const { return false; }
-bool CCoinsView::GetAddrCoins(const string &addr, CAddrTxOutMap &mapTxOut) const { return false; }
+bool CCoinsView::GetAddrCoins(const string &addr, CTxOutMap &mapTxOut) const { return false; }
 
 
 CCoinsViewBacked::CCoinsViewBacked(CCoinsView *viewIn) : base(viewIn) { }
@@ -59,7 +59,7 @@ uint256 CCoinsViewBacked::GetBestBlock() const { return base->GetBestBlock(); }
 void CCoinsViewBacked::SetBackend(CCoinsView &viewIn) { base = &viewIn; }
 bool CCoinsViewBacked::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) { return base->BatchWrite(mapCoins, hashBlock); }
 bool CCoinsViewBacked::GetStats(CCoinsStats &stats) const { return base->GetStats(stats); }
-bool CCoinsViewBacked::GetAddrCoins(const string &addr, CAddrTxOutMap &mapTxOut) const { return base->GetAddrCoins(addr, mapTxOut); }
+bool CCoinsViewBacked::GetAddrCoins(const string &addr, CTxOutMap &mapTxOut) const { return base->GetAddrCoins(addr, mapTxOut); }
 
 CCoinsKeyHasher::CCoinsKeyHasher() : salt(GetRandHash()) {}
 
@@ -251,7 +251,7 @@ double CCoinsViewCache::GetPriority(const CTransaction &tx, int nHeight) const
     return tx.ComputePriority(dResult);
 }
 
-bool CCoinsViewCache::GetAddrCoins(const string &addr, CAddrTxOutMap &mapTxOut) const { return base->GetAddrCoins(addr, mapTxOut); }
+bool CCoinsViewCache::GetAddrCoins(const string &addr, CTxOutMap &mapTxOut) const { return base->GetAddrCoins(addr, mapTxOut); }
 
 CCoinsModifier::CCoinsModifier(CCoinsViewCache& cache_, CCoinsMap::iterator it_, size_t usage) : cache(cache_), it(it_), cachedCoinUsage(usage) {
     assert(!cache.hasModifier);

--- a/src/coins.h
+++ b/src/coins.h
@@ -325,7 +325,7 @@ struct CCoinsCacheEntry
 };
 
 typedef boost::unordered_map<uint256, CCoinsCacheEntry, CCoinsKeyHasher> CCoinsMap;
-typedef std::multimap<uint256, boost::tuple<unsigned int, type_Color, CAmount> > CAddrTxOutMap;
+typedef std::multimap<uint256, std::pair<unsigned int, CTxOut> > CAddrTxOutMap;
 
 struct CCoinsStats
 {

--- a/src/coins.h
+++ b/src/coins.h
@@ -325,7 +325,7 @@ struct CCoinsCacheEntry
 };
 
 typedef boost::unordered_map<uint256, CCoinsCacheEntry, CCoinsKeyHasher> CCoinsMap;
-typedef std::multimap<uint256, std::pair<unsigned int, CTxOut> > CAddrTxOutMap;
+typedef std::map<COutPoint, CTxOut> CTxOutMap;
 
 struct CCoinsStats
 {
@@ -363,7 +363,7 @@ public:
     virtual bool GetStats(CCoinsStats &stats) const;
 
     //! Get the coins of determined address
-    virtual bool GetAddrCoins(const std::string &addr, CAddrTxOutMap &mapTxOut) const;
+    virtual bool GetAddrCoins(const std::string &addr, CTxOutMap &mapTxOut) const;
 
     //! As we use CCoinsViews polymorphically, have a virtual destructor
     virtual ~CCoinsView() {}
@@ -384,7 +384,7 @@ public:
     void SetBackend(CCoinsView &viewIn);
     bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
     bool GetStats(CCoinsStats &stats) const;
-    bool GetAddrCoins(const std::string &addr, CAddrTxOutMap &mapTxOut) const;
+    bool GetAddrCoins(const std::string &addr, CTxOutMap &mapTxOut) const;
 };
 
 
@@ -438,7 +438,7 @@ public:
     uint256 GetBestBlock() const;
     void SetBestBlock(const uint256 &hashBlock);
     bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
-    bool GetAddrCoins(const std::string &addr, CAddrTxOutMap &mapTxOut) const;
+    bool GetAddrCoins(const std::string &addr, CTxOutMap &mapTxOut) const;
 
     /**
      * Return a pointer to CCoins in the cache, or NULL if not found. This is

--- a/src/coins.h
+++ b/src/coins.h
@@ -324,6 +324,7 @@ struct CCoinsCacheEntry
 };
 
 typedef boost::unordered_map<uint256, CCoinsCacheEntry, CCoinsKeyHasher> CCoinsMap;
+typedef std::multimap<uint256, unsigned int> CAddrTxOutMap;
 
 struct CCoinsStats
 {
@@ -360,6 +361,9 @@ public:
     //! Calculate statistics about the unspent transaction output set
     virtual bool GetStats(CCoinsStats &stats) const;
 
+    //! Get the coins of determined address
+    virtual bool GetAddrCoins(const std::string &addr, CAddrTxOutMap &mapTxOut) const;
+
     //! As we use CCoinsViews polymorphically, have a virtual destructor
     virtual ~CCoinsView() {}
 };
@@ -379,6 +383,7 @@ public:
     void SetBackend(CCoinsView &viewIn);
     bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
     bool GetStats(CCoinsStats &stats) const;
+    bool GetAddrCoins(const std::string &addr, CAddrTxOutMap &mapTxOut) const;
 };
 
 
@@ -432,6 +437,7 @@ public:
     uint256 GetBestBlock() const;
     void SetBestBlock(const uint256 &hashBlock);
     bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
+    bool GetAddrCoins(const std::string &addr, CAddrTxOutMap &mapTxOut) const;
 
     /**
      * Return a pointer to CCoins in the cache, or NULL if not found. This is

--- a/src/coins.h
+++ b/src/coins.h
@@ -17,7 +17,6 @@
 #include <stdint.h>
 
 #include <boost/foreach.hpp>
-#include <boost/tuple/tuple.hpp>
 #include <boost/unordered_map.hpp>
 
 /** 

--- a/src/coins.h
+++ b/src/coins.h
@@ -17,6 +17,7 @@
 #include <stdint.h>
 
 #include <boost/foreach.hpp>
+#include <boost/tuple/tuple.hpp>
 #include <boost/unordered_map.hpp>
 
 /** 
@@ -324,7 +325,7 @@ struct CCoinsCacheEntry
 };
 
 typedef boost::unordered_map<uint256, CCoinsCacheEntry, CCoinsKeyHasher> CCoinsMap;
-typedef std::multimap<uint256, unsigned int> CAddrTxOutMap;
+typedef std::multimap<uint256, boost::tuple<unsigned int, type_Color, CAmount> > CAddrTxOutMap;
 
 struct CCoinsStats
 {

--- a/src/coins.h
+++ b/src/coins.h
@@ -363,7 +363,7 @@ public:
     virtual bool GetStats(CCoinsStats &stats) const;
 
     //! Get the coins of determined address
-    virtual bool GetAddrCoins(const std::string &addr, CTxOutMap &mapTxOut) const;
+    virtual bool GetAddrCoins(const std::string &addr, CTxOutMap &mapTxOut, bool fLicense) const;
 
     //! As we use CCoinsViews polymorphically, have a virtual destructor
     virtual ~CCoinsView() {}
@@ -384,7 +384,7 @@ public:
     void SetBackend(CCoinsView &viewIn);
     bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
     bool GetStats(CCoinsStats &stats) const;
-    bool GetAddrCoins(const std::string &addr, CTxOutMap &mapTxOut) const;
+    bool GetAddrCoins(const std::string &addr, CTxOutMap &mapTxOut, bool fLicense) const;
 };
 
 
@@ -438,7 +438,7 @@ public:
     uint256 GetBestBlock() const;
     void SetBestBlock(const uint256 &hashBlock);
     bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
-    bool GetAddrCoins(const std::string &addr, CTxOutMap &mapTxOut) const;
+    bool GetAddrCoins(const std::string &addr, CTxOutMap &mapTxOut, bool fLicense) const;
 
     /**
      * Return a pointer to CCoins in the cache, or NULL if not found. This is

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -536,13 +536,14 @@ Value gettxout(const Array& params, bool fHelp)
 
 Value gettxoutaddress(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 2)
+    if (fHelp || params.size() < 1 || params.size() > 3)
         throw std::runtime_error(
-            "gettxoutaddress \"address\" ( includemempool )\n"
+            "gettxoutaddress \"address\" ( includemempool ) ( returnlicense )\n"
             "\nReturns transaction output for a determined address.\n"
             "\nArguments:\n"
             "1. \"address\"       (string, required) The transaction id\n"
-            "2. includemempool    (boolean, optional) Whether to included the mem pool\n"
+            "2. includemempool    (boolean, optional) Whether to include the mempool\n"
+            "3. returnlicense     (numeric, optional, default=0) If 0, return coin, otherwise return license\n"
             "\nResult:\n"
             "{\n"
             "  \"tx\" : \"hash\",           (string) the transaction hash\n"
@@ -565,15 +566,19 @@ Value gettxoutaddress(const Array& params, bool fHelp)
     if (params.size() > 1)
         fMempool = params[1].get_bool();
 
+    bool fLicense = false;
+    if (params.size() > 2)
+        fLicense = (params[2].get_int() != 0);
+
     CTxOutMap mapTxOut;
     FlushStateToDisk();
     if (fMempool) {
         LOCK(mempool.cs);
         CCoinsViewMemPool view(pcoinsTip, mempool);
-        if (!view.GetAddrCoins(address, mapTxOut))
+        if (!view.GetAddrCoins(address, mapTxOut, fLicense))
             return Value::null;
     } else {
-        if (!pcoinsTip->GetAddrCoins(address, mapTxOut))
+        if (!pcoinsTip->GetAddrCoins(address, mapTxOut, fLicense))
             return Value::null;
     }
     if (mapTxOut.size() == 0)

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -581,12 +581,12 @@ Value gettxoutaddress(const Array& params, bool fHelp)
 
     Array ret;
     for (CAddrTxOutMap::iterator it = mapTxOut.begin(); it != mapTxOut.end(); it++) {
-        Object info, temp;
-        info.push_back(Pair("output_index", (uint64_t)it->second.get<0>()));
+        Object info;
+        info.push_back(Pair("txid", it->first.GetHex()));
+        info.push_back(Pair("vout", (uint64_t)it->second.get<0>()));
         info.push_back(Pair("color", (uint64_t)it->second.get<1>()));
         info.push_back(Pair("value", (uint64_t)(it->second.get<2>() / COIN)));
-        temp.push_back(Pair(it->first.ToString(), info));
-        ret.push_back(temp);
+        ret.push_back(info);
     }
 
     return ret;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -546,7 +546,9 @@ Value gettxoutaddress(const Array& params, bool fHelp)
             "\nResult:\n"
             "{\n"
             "  \"tx\" : \"hash\",           (string) the transaction hash\n"
-            "  \"vout\" : n,                (numeric) vout value\n"
+            "  \"vout\" : n,                (numeric) vout index\n"
+            "  \"color\" : n,               (numeric) color\n"
+            "  \"value\" : n,               (numeric) value\n"
             "}\n"
 
             "\nExamples:\n"
@@ -564,6 +566,7 @@ Value gettxoutaddress(const Array& params, bool fHelp)
         fMempool = params[1].get_bool();
 
     CAddrTxOutMap mapTxOut;
+    FlushStateToDisk();
     if (fMempool) {
         LOCK(mempool.cs);
         CCoinsViewMemPool view(pcoinsTip, mempool);
@@ -577,9 +580,12 @@ Value gettxoutaddress(const Array& params, bool fHelp)
         return Value::null;
 
     Array ret;
-    for (map<uint256, unsigned int>::iterator it = mapTxOut.begin(); it != mapTxOut.end(); it++) {
-        Object temp;
-        temp.push_back(Pair(it->first.ToString(), (uint64_t)it->second));
+    for (CAddrTxOutMap::iterator it = mapTxOut.begin(); it != mapTxOut.end(); it++) {
+        Object info, temp;
+        info.push_back(Pair("output_index", (uint64_t)it->second.get<0>()));
+        info.push_back(Pair("color", (uint64_t)it->second.get<1>()));
+        info.push_back(Pair("value", (uint64_t)(it->second.get<2>() / COIN)));
+        temp.push_back(Pair(it->first.ToString(), info));
         ret.push_back(temp);
     }
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -565,7 +565,7 @@ Value gettxoutaddress(const Array& params, bool fHelp)
     if (params.size() > 1)
         fMempool = params[1].get_bool();
 
-    CAddrTxOutMap mapTxOut;
+    CTxOutMap mapTxOut;
     FlushStateToDisk();
     if (fMempool) {
         LOCK(mempool.cs);
@@ -580,11 +580,12 @@ Value gettxoutaddress(const Array& params, bool fHelp)
         return Value::null;
 
     Array ret;
-    for (CAddrTxOutMap::iterator it = mapTxOut.begin(); it != mapTxOut.end(); it++) {
+    for (CTxOutMap::iterator it = mapTxOut.begin(); it != mapTxOut.end(); it++) {
         Object info;
-        unsigned int index = it->second.first;
-        CTxOut out = it->second.second;
-        info.push_back(Pair("txid", it->first.GetHex()));
+        uint256 hash = it->first.hash;
+        unsigned int index = it->first.n;
+        CTxOut out = it->second;
+        info.push_back(Pair("txid", hash.GetHex()));
         info.push_back(Pair("vout", (uint64_t)index));
         info.push_back(Pair("color", (uint64_t)out.color));
         info.push_back(Pair("value", ValueFromAmount(out.nValue)));

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -585,7 +585,7 @@ Value gettxoutaddress(const Array& params, bool fHelp)
         info.push_back(Pair("txid", it->first.GetHex()));
         info.push_back(Pair("vout", (uint64_t)it->second.get<0>()));
         info.push_back(Pair("color", (uint64_t)it->second.get<1>()));
-        info.push_back(Pair("value", (uint64_t)(it->second.get<2>() / COIN)));
+        info.push_back(Pair("value", ValueFromAmount(it->second.get<2>())));
         ret.push_back(info);
     }
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -582,10 +582,13 @@ Value gettxoutaddress(const Array& params, bool fHelp)
     Array ret;
     for (CAddrTxOutMap::iterator it = mapTxOut.begin(); it != mapTxOut.end(); it++) {
         Object info;
+        unsigned int index = it->second.first;
+        CTxOut out = it->second.second;
         info.push_back(Pair("txid", it->first.GetHex()));
-        info.push_back(Pair("vout", (uint64_t)it->second.get<0>()));
-        info.push_back(Pair("color", (uint64_t)it->second.get<1>()));
-        info.push_back(Pair("value", ValueFromAmount(it->second.get<2>())));
+        info.push_back(Pair("vout", (uint64_t)index));
+        info.push_back(Pair("color", (uint64_t)out.color));
+        info.push_back(Pair("value", ValueFromAmount(out.nValue)));
+        info.push_back(Pair("scriptPubKey", HexStr(out.scriptPubKey.begin(), out.scriptPubKey.end())));
         ret.push_back(info);
     }
 

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -112,6 +112,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "gettxout", 1 },
     { "gettxout", 2 },
     { "gettxoutaddress", 1 },
+    { "gettxoutaddress", 2 },
     { "gettxoutproof", 0 },
     { "lockunspent", 0 },
     { "lockunspent", 1 },

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -111,6 +111,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendrawtransaction", 1 },
     { "gettxout", 1 },
     { "gettxout", 2 },
+    { "gettxoutaddress", 1 },
     { "gettxoutproof", 0 },
     { "lockunspent", 0 },
     { "lockunspent", 1 },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -334,6 +334,7 @@ static const CRPCCommand vRPCCommands[] =
     { "blockchain",         "getrawmempool",               &getrawmempool,               true,      false,      false },
     { "blockchain",         "getaddrmempool",              &getaddrmempool,              true,      false,      false },
     { "blockchain",         "gettxout",                    &gettxout,                    true,      false,      false },
+    { "blockchain",         "gettxoutaddress",             &gettxoutaddress,             true,      false,      false },
     { "blockchain",         "verifytxoutproof",            &verifytxoutproof,            true,      false,      false },
     { "blockchain",         "gettxoutsetinfo",             &gettxoutsetinfo,             true,      false,      false },
     { "blockchain",         "verifychain",                 &verifychain,                 true,      false,      false },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -278,6 +278,7 @@ extern json_spirit::Value getblockhash(const json_spirit::Array& params, bool fH
 extern json_spirit::Value getblock(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gettxoutsetinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gettxout(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value gettxoutaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value verifychain(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getchaintips(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value invalidateblock(const json_spirit::Array& params, bool fHelp);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -190,7 +190,7 @@ bool CCoinsViewDB::GetAddrCoins(const string &addr, CAddrTxOutMap &mapTxOut) con
                     const CTxOut &out = coins.vout[i];
                     if (!out.IsNull() && addr == GetDestination(out.scriptPubKey) && out.nValue != 0 &&
                         (coins.type == NORMAL || coins.type == MINT || coins.type == MATCH || coins.type == CANCEL || coins.type == ORDER)) {
-                        mapTxOut.insert(pair<uint256, boost::tuple<unsigned int, type_Color, CAmount> >(txhash, boost::make_tuple(i, out.color, out.nValue)));
+                        mapTxOut.insert(pair<uint256, pair<unsigned int, CTxOut> >(txhash, make_pair(i, out)));
                     }
                 }
             }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -164,7 +164,7 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) const
     return true;
 }
 
-bool CCoinsViewDB::GetAddrCoins(const string &addr, CTxOutMap &mapTxOut) const
+bool CCoinsViewDB::GetAddrCoins(const string &addr, CTxOutMap &mapTxOut, bool fLicense) const
 {
     /* It seems that there are no "const iterators" for LevelDB.  Since we
        only need read operations on it, use a const-cast to get around
@@ -188,9 +188,11 @@ bool CCoinsViewDB::GetAddrCoins(const string &addr, CTxOutMap &mapTxOut) const
                 ssKey >> txhash;
                 for (unsigned int i = 0; i < coins.vout.size(); i++) {
                     const CTxOut &out = coins.vout[i];
-                    if (!out.IsNull() && addr == GetDestination(out.scriptPubKey) && out.nValue != 0 &&
-                        (coins.type == NORMAL || coins.type == MINT || coins.type == MATCH || coins.type == CANCEL || coins.type == ORDER)) {
-                        mapTxOut.insert(pair<COutPoint, CTxOut>(COutPoint(txhash, i), out));
+                    if (!out.IsNull() && addr == GetDestination(out.scriptPubKey) && out.nValue != 0) {
+                        if (!fLicense && (coins.type == NORMAL || coins.type == MINT))
+                            mapTxOut.insert(pair<COutPoint, CTxOut>(COutPoint(txhash, i), out));
+                        else if (fLicense && (coins.type == LICENSE))
+                            mapTxOut.insert(pair<COutPoint, CTxOut>(COutPoint(txhash, i), out));
                     }
                 }
             }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -189,7 +189,7 @@ bool CCoinsViewDB::GetAddrCoins(const string &addr, CAddrTxOutMap &mapTxOut) con
                 for (unsigned int i=0; i<coins.vout.size(); i++) {
                     const CTxOut &out = coins.vout[i];
                     if (!out.IsNull() && addr == GetDestination(out.scriptPubKey) && out.nValue != 0 ) {
-                        mapTxOut.insert(pair<uint256, unsigned int>(txhash, i));
+                        mapTxOut.insert(pair<uint256, boost::tuple<unsigned int, type_Color, CAmount> >(txhash, boost::make_tuple(i, out.color, out.nValue)));
                     }
                 }
             }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -164,7 +164,7 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) const
     return true;
 }
 
-bool CCoinsViewDB::GetAddrCoins(const string &addr, CAddrTxOutMap &mapTxOut) const
+bool CCoinsViewDB::GetAddrCoins(const string &addr, CTxOutMap &mapTxOut) const
 {
     /* It seems that there are no "const iterators" for LevelDB.  Since we
        only need read operations on it, use a const-cast to get around
@@ -186,11 +186,11 @@ bool CCoinsViewDB::GetAddrCoins(const string &addr, CAddrTxOutMap &mapTxOut) con
                 ssValue >> coins;
                 uint256 txhash;
                 ssKey >> txhash;
-                for (unsigned int i=0; i<coins.vout.size(); i++) {
+                for (unsigned int i = 0; i < coins.vout.size(); i++) {
                     const CTxOut &out = coins.vout[i];
                     if (!out.IsNull() && addr == GetDestination(out.scriptPubKey) && out.nValue != 0 &&
                         (coins.type == NORMAL || coins.type == MINT || coins.type == MATCH || coins.type == CANCEL || coins.type == ORDER)) {
-                        mapTxOut.insert(pair<uint256, pair<unsigned int, CTxOut> >(txhash, make_pair(i, out)));
+                        mapTxOut.insert(pair<COutPoint, CTxOut>(COutPoint(txhash, i), out));
                     }
                 }
             }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -188,7 +188,8 @@ bool CCoinsViewDB::GetAddrCoins(const string &addr, CAddrTxOutMap &mapTxOut) con
                 ssKey >> txhash;
                 for (unsigned int i=0; i<coins.vout.size(); i++) {
                     const CTxOut &out = coins.vout[i];
-                    if (!out.IsNull() && addr == GetDestination(out.scriptPubKey) && out.nValue != 0 ) {
+                    if (!out.IsNull() && addr == GetDestination(out.scriptPubKey) && out.nValue != 0 &&
+                        (coins.type == NORMAL || coins.type == MINT || coins.type == MATCH || coins.type == CANCEL || coins.type == ORDER)) {
                         mapTxOut.insert(pair<uint256, boost::tuple<unsigned int, type_Color, CAmount> >(txhash, boost::make_tuple(i, out.color, out.nValue)));
                     }
                 }

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -39,6 +39,7 @@ public:
     uint256 GetBestBlock() const;
     bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
     bool GetStats(CCoinsStats &stats) const;
+    bool GetAddrCoins(const std::string &addr, CAddrTxOutMap &mapTxOut) const;
 };
 
 /** Access to the block database (blocks/index/) */

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -39,7 +39,7 @@ public:
     uint256 GetBestBlock() const;
     bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
     bool GetStats(CCoinsStats &stats) const;
-    bool GetAddrCoins(const std::string &addr, CAddrTxOutMap &mapTxOut) const;
+    bool GetAddrCoins(const std::string &addr, CTxOutMap &mapTxOut) const;
 };
 
 /** Access to the block database (blocks/index/) */

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -39,7 +39,7 @@ public:
     uint256 GetBestBlock() const;
     bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
     bool GetStats(CCoinsStats &stats) const;
-    bool GetAddrCoins(const std::string &addr, CTxOutMap &mapTxOut) const;
+    bool GetAddrCoins(const std::string &addr, CTxOutMap &mapTxOut, bool fLicense) const;
 };
 
 /** Access to the block database (blocks/index/) */

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -444,3 +444,18 @@ bool CCoinsViewMemPool::HaveCoins(const uint256 &txid) const
 {
     return mempool.exists(txid) || base->HaveCoins(txid);
 }
+
+bool CCoinsViewMemPool::GetAddrCoins(const string &addr, CAddrTxOutMap &mapTxOut) const
+{
+    for (map<uint256, CTxMemPoolEntry>::iterator it = mempool.mapTx.begin(); it != mempool.mapTx.end(); it++) {
+        CTransaction tmp;
+        tmp = it->second.GetTx();
+        for (unsigned int i = 0; i < tmp.vout.size(); i++) {
+            const CTxOut &out = tmp.vout[i];
+            if (!out.IsNull() && addr == GetDestination(out.scriptPubKey) && out.nValue != 0 )
+                mapTxOut.insert(pair<uint256, unsigned int>(tmp.GetHash(), i));
+        }
+    }
+    base->GetAddrCoins(addr, mapTxOut);
+    return true;
+}

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -452,11 +452,6 @@ bool CCoinsViewMemPool::GetAddrCoins(const string &addr, CTxOutMap &mapTxOut, bo
     for (map<uint256, CTxMemPoolEntry>::iterator it = mempool.mapTx.begin(); it != mempool.mapTx.end(); it++) {
         CTransaction tx;
         tx = it->second.GetTx();
-        for (unsigned int i = 0; i < tx.vin.size(); i++) {
-            uint256 hash = tx.vin[i].prevout.hash;
-            uint32_t n = tx.vin[i].prevout.n;
-            mapTxOut.erase(COutPoint(hash, n));
-        }
         for (unsigned int i = 0; i < tx.vout.size(); i++) {
             const CTxOut &out = tx.vout[i];
             if (!out.IsNull() && addr == GetDestination(out.scriptPubKey) && out.nValue != 0) {
@@ -465,6 +460,16 @@ bool CCoinsViewMemPool::GetAddrCoins(const string &addr, CTxOutMap &mapTxOut, bo
                 else if (fLicense && (tx.type == LICENSE))
                     mapTxOut.insert(pair<COutPoint, CTxOut>(COutPoint(tx.GetHash(), i), out));
             }
+        }
+    }
+
+    for (map<uint256, CTxMemPoolEntry>::iterator it = mempool.mapTx.begin(); it != mempool.mapTx.end(); it++) {
+        CTransaction tx;
+        tx = it->second.GetTx();
+        for (unsigned int i = 0; i < tx.vin.size(); i++) {
+            uint256 hash = tx.vin[i].prevout.hash;
+            uint32_t n = tx.vin[i].prevout.n;
+            mapTxOut.erase(COutPoint(hash, n));
         }
     }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -453,7 +453,7 @@ bool CCoinsViewMemPool::GetAddrCoins(const string &addr, CAddrTxOutMap &mapTxOut
         for (unsigned int i = 0; i < tmp.vout.size(); i++) {
             const CTxOut &out = tmp.vout[i];
             if (!out.IsNull() && addr == GetDestination(out.scriptPubKey) && out.nValue != 0 )
-                mapTxOut.insert(pair<uint256, unsigned int>(tmp.GetHash(), i));
+                mapTxOut.insert(pair<uint256, boost::tuple<unsigned int, type_Color, CAmount> >(tmp.GetHash(), boost::make_tuple(i, out.color, out.nValue)));
         }
     }
     base->GetAddrCoins(addr, mapTxOut);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -452,7 +452,8 @@ bool CCoinsViewMemPool::GetAddrCoins(const string &addr, CAddrTxOutMap &mapTxOut
         tmp = it->second.GetTx();
         for (unsigned int i = 0; i < tmp.vout.size(); i++) {
             const CTxOut &out = tmp.vout[i];
-            if (!out.IsNull() && addr == GetDestination(out.scriptPubKey) && out.nValue != 0 )
+            if (!out.IsNull() && addr == GetDestination(out.scriptPubKey) && out.nValue != 0 &&
+                (tmp.type == NORMAL || tmp.type == MINT || tmp.type == MATCH || tmp.type == CANCEL || tmp.type == ORDER))
                 mapTxOut.insert(pair<uint256, boost::tuple<unsigned int, type_Color, CAmount> >(tmp.GetHash(), boost::make_tuple(i, out.color, out.nValue)));
         }
     }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -445,25 +445,28 @@ bool CCoinsViewMemPool::HaveCoins(const uint256 &txid) const
     return mempool.exists(txid) || base->HaveCoins(txid);
 }
 
-bool CCoinsViewMemPool::GetAddrCoins(const string &addr, CTxOutMap &mapTxOut) const
+bool CCoinsViewMemPool::GetAddrCoins(const string &addr, CTxOutMap &mapTxOut, bool fLicense) const
 {
+    base->GetAddrCoins(addr, mapTxOut, fLicense);
+
     for (map<uint256, CTxMemPoolEntry>::iterator it = mempool.mapTx.begin(); it != mempool.mapTx.end(); it++) {
         CTransaction tx;
         tx = it->second.GetTx();
-        if (!mempool.HasNoInputsOf(tx)) {
-            for (unsigned int i = 0; i < tx.vin.size(); i++) {
-                uint256 hash = tx.vin[i].prevout.hash;
-                uint32_t n = tx.vin[i].prevout.n;
-                mapTxOut.erase(COutPoint(hash, n));
-            }
+        for (unsigned int i = 0; i < tx.vin.size(); i++) {
+            uint256 hash = tx.vin[i].prevout.hash;
+            uint32_t n = tx.vin[i].prevout.n;
+            mapTxOut.erase(COutPoint(hash, n));
         }
         for (unsigned int i = 0; i < tx.vout.size(); i++) {
             const CTxOut &out = tx.vout[i];
-            if (!out.IsNull() && addr == GetDestination(out.scriptPubKey) && out.nValue != 0 &&
-                (tx.type == NORMAL || tx.type == MINT || tx.type == MATCH || tx.type == CANCEL || tx.type == ORDER))
-                mapTxOut.insert(pair<COutPoint, CTxOut>(COutPoint(tx.GetHash(), i), out));
+            if (!out.IsNull() && addr == GetDestination(out.scriptPubKey) && out.nValue != 0) {
+                if (!fLicense && (tx.type == NORMAL || tx.type == MINT))
+                    mapTxOut.insert(pair<COutPoint, CTxOut>(COutPoint(tx.GetHash(), i), out));
+                else if (fLicense && (tx.type == LICENSE))
+                    mapTxOut.insert(pair<COutPoint, CTxOut>(COutPoint(tx.GetHash(), i), out));
+            }
         }
     }
-    base->GetAddrCoins(addr, mapTxOut);
+
     return true;
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -454,7 +454,7 @@ bool CCoinsViewMemPool::GetAddrCoins(const string &addr, CAddrTxOutMap &mapTxOut
             const CTxOut &out = tmp.vout[i];
             if (!out.IsNull() && addr == GetDestination(out.scriptPubKey) && out.nValue != 0 &&
                 (tmp.type == NORMAL || tmp.type == MINT || tmp.type == MATCH || tmp.type == CANCEL || tmp.type == ORDER))
-                mapTxOut.insert(pair<uint256, boost::tuple<unsigned int, type_Color, CAmount> >(tmp.GetHash(), boost::make_tuple(i, out.color, out.nValue)));
+                mapTxOut.insert(pair<uint256, pair<unsigned int, CTxOut> >(tmp.GetHash(), make_pair(i, out)));
         }
     }
     base->GetAddrCoins(addr, mapTxOut);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -179,7 +179,7 @@ public:
     CCoinsViewMemPool(CCoinsView *baseIn, CTxMemPool &mempoolIn);
     bool GetCoins(const uint256 &txid, CCoins &coins) const;
     bool HaveCoins(const uint256 &txid) const;
-    bool GetAddrCoins(const std::string &addr, CAddrTxOutMap &mapTxOut) const;
+    bool GetAddrCoins(const std::string &addr, CTxOutMap &mapTxOut) const;
 
 };
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -179,6 +179,8 @@ public:
     CCoinsViewMemPool(CCoinsView *baseIn, CTxMemPool &mempoolIn);
     bool GetCoins(const uint256 &txid, CCoins &coins) const;
     bool HaveCoins(const uint256 &txid) const;
+    bool GetAddrCoins(const std::string &addr, CAddrTxOutMap &mapTxOut) const;
+
 };
 
 #endif // BITCOIN_TXMEMPOOL_H

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -179,7 +179,7 @@ public:
     CCoinsViewMemPool(CCoinsView *baseIn, CTxMemPool &mempoolIn);
     bool GetCoins(const uint256 &txid, CCoins &coins) const;
     bool HaveCoins(const uint256 &txid) const;
-    bool GetAddrCoins(const std::string &addr, CTxOutMap &mapTxOut) const;
+    bool GetAddrCoins(const std::string &addr, CTxOutMap &mapTxOut, bool fLicense) const;
 
 };
 


### PR DESCRIPTION
Implement by @hihiben 
Implement functions
CCoinsView::GetAddrCoins
CCoinsViewDB::GetAddrCoins
CCoinsViewBacked::GetAddrCoins
CCoinsViewCache::GetAddrCoins
CCoinsViewMemPool::GetAddrCoins
Only returns the txouts that value is not 0 for simplifying the result.

Implement RPC
gettxoutaddress
Usage:
gettxoutaddress "address" checkingmempool(bool) listlicense(bool)
checkingmempool is optional and true as default
listlicense is optional and false as default

Return:
tx hash vout index

Execution requires querying entire database, may take some time.