### PR TITLE
rpc addalliance

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -82,8 +82,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listsinceblock", 2 },
     { "addminer", 1 },
     { "revokeminer", 1 },
-    { "setalliance", 1 },
-    { "addalliance", 1 },
     { "getlicenseinfo", 0 },
     { "getlicenselist", 0 },
     { "encodelicenseinfo", 0 },

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -83,6 +83,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "addminer", 1 },
     { "revokeminer", 1 },
     { "setalliance", 1 },
+    { "addalliance", 1 },
     { "getlicenseinfo", 0 },
     { "getlicenselist", 0 },
     { "encodelicenseinfo", 0 },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -389,6 +389,7 @@ static const CRPCCommand vRPCCommands[] =
     { "wallet",             "addminer",                    &addminer,                    false,     false,      true },
     { "wallet",             "revokeminer",                 &revokeminer,                 false,     false,      true },
     { "wallet",             "setalliance",                 &setalliance,                 false,     false,      true },
+    { "wallet",             "addalliance",                 &addalliance,                 false,     false,      true },
     { "wallet",             "mint",                        &mint,                        false,     false,      true },
     { "wallet",             "mintforlicense",              &mintforlicense,              false,     false,      true },
     { "wallet",             "mintforminer",                &mintforminer,                false,     false,      true },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -248,6 +248,7 @@ extern json_spirit::Value sendlicensetoaddress(const json_spirit::Array& params,
 extern json_spirit::Value addminer(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value revokeminer(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value setalliance(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value addalliance(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value mint(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value mintforlicense(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value mintforminer(const json_spirit::Array& params, bool fHelp);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -765,7 +765,7 @@ Value setalliance(const Array& params, bool fHelp)
     if (!EnsureWalletIsAvailable(fHelp))
         return Value::null;
 
-    if (fHelp || params.size() < 1 || params.size() > 3)
+    if (fHelp || params.size() != 1)
         throw runtime_error(
             "setalliance \"redeemscript\n"
             "\nTransfer alliance token from multi-sig of alliance group to multi-sig of new group.\n"
@@ -788,7 +788,6 @@ Value setalliance(const Array& params, bool fHelp)
     vector<unsigned char> rsData(ParseHexV(params[0], "redeemScript"));
     CScript redeemScript(rsData.begin(), rsData.end());
 
-    // Wallet comments
     CWalletTx wtx;
 
     EnsureWalletIsUnlocked();
@@ -809,7 +808,7 @@ Value addalliance(const Array& params, bool fHelp)
     if (!EnsureWalletIsAvailable(fHelp))
         return Value::null;
 
-    if (fHelp || params.size() < 1 || params.size() > 3)
+    if (fHelp || params.size() != 1)
         throw runtime_error(
             "addalliance \"pubkey\n"
             "\nAdd alliance member.\n"
@@ -843,7 +842,6 @@ Value addalliance(const Array& params, bool fHelp)
     int nRequired = keys.size() * Params().AllianceThreshold();
     CScript redeemScript = _createmultisig_redeemScript(max(nRequired, 1), keys);
 
-    // Wallet comments
     CWalletTx wtx;
 
     EnsureWalletIsUnlocked();


### PR DESCRIPTION
A new rpc to add a node to alliance member.
It's a convenient way to add a single alliance compare to setalliacne.

Usage : 
addalliance [pubkey of candidate] 