### PR TITLE
Fix scope problem of CCoinsModifier #120

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2825,7 +2825,7 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
 
         // Check that all outputs are available and match the outputs in the block itself
         // exactly.
-
+        {
         CCoinsModifier outs = view.ModifyCoins(hash);
         outs->ClearUnspendable();
 
@@ -2848,6 +2848,7 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
 
         // remove outputs
         outs->Clear();
+        }
 
         if (!tx.IsCoinBase()) { // not coinbases
         // restore inputs


### PR DESCRIPTION
在 e30d183 中將括號修掉, scope的變動導致CCoinsModifier的destructor沒有正常運作,
因此造成 #120 中的問題