### PR TITLE
Fix assignfixedaddress #135

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -686,7 +686,7 @@ void GenerateGcoins(bool fGenerate, CWallet* pwallet, int nThreads)
     //only miner can mine block
     std::string addr = CBitcoinAddress(pubkey.GetID()).ToString();
     if (!pminer->IsMiner(addr)) {
-        mapArgs["-gen"] = "false";
+        mapArgs["-gen"] = "0";
         return;
     }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -9,6 +9,7 @@
 #include "core_io.h"
 #include "init.h"
 #include "main.h"
+#include "miner.h"
 #include "net.h"
 #include "netbase.h"
 #include "rpcserver.h"
@@ -174,11 +175,21 @@ Value assignfixedaddress(const Array& params, bool fHelp)
         }
     }
 
+    GenerateGcoins(false, pwalletMain, atoi(mapArgs["-genproclimit"]));
+
     if (newDefaultKey.IsValid()) {
         pwalletMain->SetDefaultKey(newDefaultKey);
         keyID = pwalletMain->vchDefaultKey.GetID();
         if (!pwalletMain->SetAddressBook(keyID, "", "receive"))
             throw JSONRPCError(RPC_WALLET_ERROR, "Cannot write default address");
+    }
+
+    if (mapArgs["-gen"] == "1") {
+        GenerateGcoins(true, pwalletMain, atoi(mapArgs["-genproclimit"]));
+        if (mapArgs["-gen"] == "1")
+            str += " mining continues";
+        else
+            str += " mining stops";
     }
 
     return str;


### PR DESCRIPTION
Default address change while mining might crash.
Stop mining and restart the procedure after the address is assigned.